### PR TITLE
Increase far clip distance

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -189,7 +189,9 @@ void reshape(int w, int h) {
     glViewport(0,0,w,h);
     glMatrixMode(GL_PROJECTION);
     glLoadIdentity();
-    gluPerspective(45.0f, (float)w/h, 0.1f, 100.0f);
+    // Increase the far clipping plane to avoid culling animated models that
+    // move further from the origin.
+    gluPerspective(45.0f, (float)w/h, 0.1f, 1000.0f);
     glMatrixMode(GL_MODELVIEW);
 }
 


### PR DESCRIPTION
## Summary
- avoid culling animated models by increasing the projection's far plane

## Testing
- `g++ -std=c++11 main.cpp -lGL -lGLU -lglut -lassimp -o arcadia` *(fails: GL/glut.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_6867f0274e1883328a7765390579f4a9