### PR TITLE
Initialize BoneInfo transform

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -96,8 +96,9 @@ void loadModel(const std::string& path) {
             if(it == boneMapping.end()) {
                 boneIndex = boneInfo.size();
                 boneMapping[bone->mName.C_Str()] = boneIndex;
-                BoneInfo info;
+                BoneInfo info{};
                 info.offset = bone->mOffsetMatrix;
+                info.finalTransform = aiMatrix4x4();
                 boneInfo.push_back(info);
             } else {
                 boneIndex = it->second;


### PR DESCRIPTION
## Summary
- initialize `BoneInfo` structs in `loadModel` to avoid uninitialised values

## Testing
- `g++ -std=c++11 main.cpp -o main -lGL -lGLU -lglut -lassimp` *(fails: GL/glut.h not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868f4287dd48332a41c853d1b7e79c6